### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -55,7 +55,7 @@
 
   <releases>
     <release version="3.1.3">
-      <description>
+      <description translatable="no">
         <p>Updated translations</p>
         <ul>
           <li>Updated Ukrainian translations thanks to Volkov (@Vovkiv on GitHub)</li>
@@ -64,7 +64,7 @@
       </description>
     </release>
     <release version="3.1.2" date="2023-09-25">
-      <description>
+      <description translatable="no">
         <p>Deep Purple</p>
         <ul>
           <li>New look inspired by the deep purples from the icon</li>
@@ -79,7 +79,7 @@
       </description>
     </release>
     <release version="3.0.6" date="2023-04-03">
-      <description>
+      <description translatable="no">
         <p>Translations and GNOME 44</p>
         <ul>
           <li>German translations thanks to @FineFindus on GitHub</li>
@@ -91,7 +91,7 @@
       </description>
     </release>
     <release version="3.0.5" date="2023-03-15">
-      <description>
+      <description translatable="no">
         <p>Update for GNOME Circle consideration</p>
         <ul>
           <li>Close with Ctrl+Q and Ctrl+W</li>
@@ -101,17 +101,17 @@
       </description>
     </release>
     <release version="3.0.4" date="2023-01-19">
-      <description>
+      <description translatable="no">
         <p>Subtly improved icon; it should be more visible in the app grid, dash, and anywhere else with a dark background</p>
       </description>
     </release>
     <release version="3.0.3" date="2022-09-28">
-      <description>
+      <description translatable="no">
         <p>Hotfix: fix About window when closing and re-opening it</p>
       </description>
     </release>
     <release version="3.0.2" date="2022-09-27">
-      <description>
+      <description translatable="no">
         <p>More fun for everyone</p>
         <ul>
           <li>Added eight more original replies</li>
@@ -123,12 +123,12 @@
       </description>
     </release>
     <release version="3.0.1" date="2022-09-09">
-      <description>
+      <description translatable="no">
          <p>Hotfix: fix a crash on startup from trying to access nonexistent settings</p>
       </description>
     </release>
     <release version="3.0.0" date="2022-09-08">
-      <description>
+      <description translatable="no">
          <p>Hello, GNOME</p>
          <ul>
            <li>Whole new UI</li>
@@ -138,7 +138,7 @@
       </description>
     </release>
     <release version="2.0.0" date="2021-08-09">
-      <description>
+      <description translatable="no">
         <p>Hello, Odin</p>
         <ul>
           <li>Updated for OS 6 and Flatpak</li>
@@ -149,42 +149,42 @@
       </description>
     </release>
     <release version="1.1.4" date="2020-02-20">
-      <description>
+      <description translatable="no">
         <p>Refreshed icons thanks to Micah Ilbery</p>
       </description>
     </release>
     <release version="1.1.3" date="2020-02-17">
-      <description>
+      <description translatable="no">
         <p>Polish translations thanks to Michał Nowakowski</p>
       </description>
     </release>
     <release version="1.1.2" date="2019-04-09">
-      <description>
+      <description translatable="no">
         <p>Dutch translations thanks to Heimen Stoffels</p>
       </description>
     </release>
     <release version="1.1.1" date="2019-03-23">
-      <description>
+      <description translatable="no">
         <p>French translations thanks to @NathanBnm</p>
       </description>
     </release>
     <release version="1.1.0" date="2019-01-25">
-      <description>
+      <description translatable="no">
         <p>Clairvoyant is now translatable.</p>
       </description>
     </release>
     <release version="1.0.4" date="2019-01-04">
-      <description>
+      <description translatable="no">
         <p>Happy new year! This release contains AppData fixes.</p>
       </description>
     </release>
     <release version="1.0.2" date="2018-07-23">
-      <description>
+      <description translatable="no">
         <p>Fix 48px icon</p>
       </description>
     </release>
     <release version="1.0.1" date="2018-07-20">
-      <description>
+      <description translatable="no">
         <p>Post-release update</p>
         <ul>
           <li>Clean up AppStream data</li>
@@ -194,7 +194,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2018-07-20">
-      <description>
+      <description translatable="no">
         <p>It is decidedly so.</p>
         <ul>
           <li>Initial release</li>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.