### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/com.github.cassidyjames.clairvoyant.json
+++ b/com.github.cassidyjames.clairvoyant.json
@@ -14,6 +14,7 @@
     {
       "name": "clairvoyant",
       "buildsystem": "meson",
+      "run-tests": true,
       "sources": [
         {
           "type": "dir",

--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ install_data(
   rename: meson.project_name() + '-symbolic.svg'
 )
 
-i18n.merge_file(
+desktop_file = i18n.merge_file(
   input: 'launcher.desktop.in',
   output: meson.project_name() + '.desktop',
   po_dir: join_paths(meson.project_source_root(), 'po'),
@@ -18,7 +18,15 @@ i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'applications')
 )
 
-i18n.merge_file(
+# Validate Desktop
+desktop_utils = find_program('desktop-file-validate', required: false)
+if desktop_utils.found()
+  test('validate-desktop', desktop_utils,
+    args: [desktop_file]
+  )
+endif
+
+metainfo_file = i18n.merge_file(
   input: 'metainfo.appdata.xml.in',
   output: meson.project_name() + '.metainfo.xml',
   po_dir: join_paths(meson.project_source_root(), 'po'),
@@ -26,3 +34,13 @@ i18n.merge_file(
   install: true,
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
+
+# Validate Appdata
+appstreamcli = find_program('appstreamcli', required: false)
+if (appstreamcli.found())
+  test('validate-appdata',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', metainfo_file],
+    workdir: meson.current_build_dir()
+  )
+endif

--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -7,7 +7,10 @@
 
   <name>Clairvoyant</name>
   <summary>Ask questions, get psychic answers</summary>
-  <developer_name>Cassidy James Blaede</developer_name>
+  <developer_name translatable="no">Cassidy James Blaede</developer_name>
+  <developer id="github.com">
+    <name translatable="no">Cassidy James Blaede</name>
+  </developer>
   <description>
     <p>Does he love you? Should you have pizza for dinner? Is there such thing as a stupid question? Discover the answers to these questions and more with Clairvoyant, the magic 8-ball inspired fortune teller.</p>
     <ul>
@@ -54,7 +57,7 @@
   </screenshots>
 
   <releases>
-    <release version="3.1.3">
+<!--    <release version="3.1.3" date="2023-12-28">
       <description>
         <p>Updated translations</p>
         <ul>
@@ -62,7 +65,7 @@
           <li>Updated Russian translations thanks to Sergej A. (@Ser82-png on GitHub)</li>
         </ul>
       </description>
-    </release>
+    </release>-->
     <release version="3.1.2" date="2023-09-25">
       <description>
         <p>Deep Purple</p>
@@ -203,7 +206,7 @@
     </release>
   </releases>
 
-  <content_rating type="oars-1.1"></content_rating>
+  <content_rating type="oars-1.1" />
 
   <url type="homepage">https://cassidyjames.com</url>
   <url type="bugtracker">https://github.com/cassidyjames/clairvoyant/issues</url>


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Mark the developer name as untranslatable
- Update the content_rating tag
- Comment out the unreleased version tag for appstreamcli validation
- Integrate appstreamcli for appdata validation
- Use desktop-file-validate to validate desktop file
- Activate meson test to validate appdata on the build process