### PR TITLE
Update es.po - Fix small typo in Spanish

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -62,7 +62,7 @@ msgstr ""
 #: data/metainfo.appdata.xml.in:25
 msgid "Do what you'd like with the answers—just don't shoot the messenger!"
 msgstr ""
-"¡Haz lo que quieras con las respuestas, sólo no le dispares al mensajero!"
+"¡Haz lo que quieras con las respuestas, pero no dispares al mensajero!"
 
 #: data/metainfo.appdata.xml.in:36 data/metainfo.appdata.xml.in:48
 #, fuzzy
@@ -507,7 +507,7 @@ msgstr "@kevincos5, @ingrownmink4"
 
 #: src/MainWindow.vala:52
 msgid "Ask Again"
-msgstr "Pregúnta de nuevo."
+msgstr "Pregunta de nuevo."
 
 #: src/MainWindow.vala:59
 msgid "Unsupported version of this app"


### PR DESCRIPTION
Fixed the typo on the word "Pregúnta"*: in this case, it doesn't have accents, so it has been corrected to "Pregunta".
Also changed the "just don't shoot the messenger" description with "pero no dispares al mensajero".

Notice: this is my first ever contribution. Please, blame me if I did something wrong. This is a whole new world for me...